### PR TITLE
allow for failure on blank description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ branding:
 inputs:
   github-token:
     description: "Github token, added magically"
+  allowEmpty:
+    description: "Boolean - true will only throw a warning if the body is empty, false will fail the run"
+    default: true
   bodyContains:
     description: "String or |-separated array of strings, one of which must be contained in the PR body, can be left blank or omitted"
   bodyDoesNotContain:

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,8 @@ async function run() {
     // Check if the body contains required string
     const bodyContains = core.getInput("bodyContains");
     const bodyDoesNotContain = core.getInput("bodyDoesNotContain");
+    //Check if a description is required
+    const allowEmpty = core.getInput("allowEmpty");
 
     if (
       context.eventName !== "pull_request" &&
@@ -67,13 +69,18 @@ async function run() {
       if (!repository) {
         core.setFailed("❌ Expecting repository metadata.")
         return;
-      }
+      } else
       if (bodyContains || bodyDoesNotContain) {
         const PRBody = pull_request?.body;
         core.info("Checking body contents");
-        if (!PRBody) {
-          core.warning("⚠️ The PR body is empty, skipping checks");
-        } else {
+        if (!PRBody && allowEmpty) {
+            core.warning("⚠️ The PR body is empty, skipping checks");
+          
+        } else if(!PRBody && !allowEmpty){
+          core.setFailed(
+            "The PR body is empty. Please add info."
+          );
+        }else {
           if (bodyContains && !rexify(bodyContains).test(PRBody)) {
             core.setFailed(
               "The body of the PR does not contain " + bodyContains

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ async function run() {
           
         } else if(!PRBody && !allowEmpty){
           core.setFailed(
-            "The PR body is empty. Please add info."
+            "❌ The PR body is empty. Please add info."
           );
         }else {
           if (bodyContains && !rexify(bodyContains).test(PRBody)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,8 +69,7 @@ async function run() {
       if (!repository) {
         core.setFailed("❌ Expecting repository metadata.")
         return;
-      } else
-      if (bodyContains || bodyDoesNotContain) {
+      } else if (bodyContains || bodyDoesNotContain) {
         const PRBody = pull_request?.body;
         core.info("Checking body contents");
         if (!PRBody && allowEmpty) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,18 +69,19 @@ async function run() {
       if (!repository) {
         core.setFailed("❌ Expecting repository metadata.")
         return;
-      } 
+      }
       if (bodyContains || bodyDoesNotContain) {
         const PRBody = pull_request?.body;
         core.info("Checking body contents");
-        if (!PRBody && allowEmpty) {
+        if (!PRBody) {
+          if(allowEmpty) {
             core.warning("⚠️ The PR body is empty, skipping checks");
-          
-        } else if(!PRBody && !allowEmpty){
-          core.setFailed(
-            "❌ The PR body is empty. Please add info."
-          );
-        }else {
+          } else {
+            core.setFailed(
+              "❌ The PR body is empty. Please add info."
+            );
+          }
+        } else {
           if (bodyContains && !rexify(bodyContains).test(PRBody)) {
             core.setFailed(
               "The body of the PR does not contain " + bodyContains

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,8 @@ async function run() {
       if (!repository) {
         core.setFailed("❌ Expecting repository metadata.")
         return;
-      } else if (bodyContains || bodyDoesNotContain) {
+      } 
+      if (bodyContains || bodyDoesNotContain) {
         const PRBody = pull_request?.body;
         core.info("Checking body contents");
         if (!PRBody && allowEmpty) {


### PR DESCRIPTION
# Allow for failure on blank description

- [x] Check this box.

## What this PR is about
This introduces an allowEmpty option. 
true - means that the action will continue to work as it currently does, throwing only a warning when the body is empty. 
false - means that the action will fail when the body is empty. 

Should resolve #140 