### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-PRs-here.yaml
+++ b/.github/workflows/check-PRs-here.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check_pr:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check PR

--- a/.github/workflows/check-PRs-here.yaml
+++ b/.github/workflows/check-PRs-here.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   check_pr:
     permissions:
-      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Check PR

--- a/.github/workflows/local-testing.yaml
+++ b/.github/workflows/local-testing.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   dev_check_pr:
     name: "Checks dev version"
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/JJ/github-pr-contains-action/security/code-scanning/1](https://github.com/JJ/github-pr-contains-action/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job, granting only the minimum scopes required. Since this workflow only inspects PR body and payload and does not itself modify repository contents, a safe minimal starting point is `contents: read`, which allows reading the repo, and, if the action doesn’t need to write anything, no write scopes at all. If the third-party action requires additional rights (for example to post comments or update PRs), the relevant fine-grained permissions (such as `pull-requests: write`) could be added later.

The single best fix here, without changing existing functionality, is to add a `permissions` block at the job level under `check_pr:`. This keeps the change local to this job and avoids affecting any other jobs that might exist in the same workflow file. Concretely, in `.github/workflows/check-PRs-here.yaml`, under `jobs:`, for the `check_pr` job, insert a `permissions:` mapping between `check_pr:` and `runs-on: ubuntu-latest`. We’ll start with `contents: read`, which is the minimal commonly recommended scope for workflows that only need to read repository data. No new imports or additional methods are needed since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
